### PR TITLE
Minor improvements to build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -112,8 +112,9 @@ llvm-lto "${POSTGRES_BC}" \
 
 # create an archive which the Rust crate will statically link
 llvm-ar crv "${POSTGRES_PARSER_A}" "${TARGET_DIR}/raw_parser.o" || exit 1
-echo "${POSTGRES_PARSER_A};${INSTALL_DIR}"
 
 # create dynamic shared object
 CFLAGS="{$CFLAGS}" ${CC} -shared -o "${POSTGRES_PARSER_SO}" "${TARGET_DIR}/raw_parser.o" || exit 1
-echo "${POSTGRES_PARSER_SO};${INSTALL_DIR}"
+
+# output the static library information
+echo "${POSTGRES_PARSER_A};${INSTALL_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ if [ ! -f "${POSTGRES_LL}" ] ; then
     ln -s /usr/bin/ld.gold build_bin/ld || exit 1
     CFLAGS="-B${PWD}/build_bin"
   fi
-  AR="llvm-ar" CC="clang" CFLAGS="${CFLAGS} -flto" ./configure --without-readline --without-zlib --prefix="${INSTALL_DIR}" || exit 1
+  AR="llvm-ar" CC="clang" CFLAGS="${CFLAGS} -flto -fPIC" ./configure --without-readline --without-zlib --prefix="${INSTALL_DIR}" || exit 1
   make -j${NUM_CPUS} clean || exit 1
   make -j${NUM_CPUS} || exit 1
   rm -rf "${INSTALL_DIR}" || exit 1

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ set -x
 
 TARGET_DIR=${CARGO_TARGET_DIR}
 if [ "x${TARGET_DIR}" == "x" ] ; then
-  TARGET_DIR="${PWD}/target/"
+  TARGET_DIR="${PWD}/target"
 fi
 UNAME=$(uname)
 MANIFEST_DIR="${PWD}"
@@ -29,7 +29,7 @@ POSTGRES_PARSER_A="${TARGET_DIR}/libpostgres_parser.a"
 POSTGRES_BC="${TARGET_DIR}/postgres.bc"
 BUILD_DIR="${TARGET_DIR}/${PGVER}-build"
 POSTGRES_LL="${BUILD_DIR}/postgresql-${PGVER}/src/backend/postgres.ll"
-INSTALL_DIR="${BUILD_DIR}/postgresql-${PGVER}/temp-install/"
+INSTALL_DIR="${BUILD_DIR}/postgresql-${PGVER}/temp-install"
 
 if [ "x${NUM_CPUS}" == "x" ]; then
     NUM_CPUS="1"
@@ -47,7 +47,7 @@ if [ ! -f "${POSTGRES_LL}" ] ; then
 
   # download/untar Postgres
   if [ ! -f postgresql-${PGVER}.tar.bz2 ] ; then
-    wget -q https://ftp.postgresql.org/pub/source/v12.3/postgresql-${PGVER}.tar.bz2 || exit 1
+    wget -q https://ftp.postgresql.org/pub/source/v${PGVER}/postgresql-${PGVER}.tar.bz2 || exit 1
   fi
   tar xjf postgresql-${PGVER}.tar.bz2 || exit 1
 


### PR DESCRIPTION
1. Use of  variable instead of hardcoded and some minor directory naming fixes

2. Added -fPIC flag to enable the raw_parser.o file be compiled as a shared object